### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project follows the [Model Context Protocol](https://modelcontextprotocol.com/) standard, allowing AI assistants to interact with Square's connect API.
 
+<a href="https://glama.ai/mcp/servers/@square/square-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@square/square-mcp-server/badge" alt="Square Model Context Protocol Server MCP server" />
+</a>
+
 ## Quick Start
 
 Get up and running with the Square MCP server using npx:


### PR DESCRIPTION
This PR adds a badge for the [Square Model Context Protocol Server](https://glama.ai/mcp/servers/@square/square-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@square/square-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@square/square-mcp-server/badge" alt="Square Model Context Protocol Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.