### PR TITLE
Add DCO check to all PRs and commits

### DIFF
--- a/.github/workflows/dco-cla.yml
+++ b/.github/workflows/dco-cla.yml
@@ -1,0 +1,7 @@
+name: DCO/CLA Verification
+on:
+  pull_request:
+  push:
+jobs:
+  dco-cla:
+    uses: block/ospo/.github/workflows/dco-cla.yaml@main


### PR DESCRIPTION
This adds a check to all PRs and commits to make sure that all commits by external parties contain a [Developer Certificate of Origin](https://wiki.linuxfoundation.org/dco).