### PR TITLE
feat - tests + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,12 @@ npx @modelcontextprotocol/inspector node dist/index.js start
 ## Contributing
 
 This repository is auto-generated from Square's OpenAPI Specification. While contributions are welcome, please note that changes will need to be incorporated into the generator that produces this code. Please open an issue to discuss proposed changes before submitting a pull request.
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval evals.ts server.ts
+```

--- a/evals.ts
+++ b/evals.ts
@@ -1,0 +1,41 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const make_api_requestEval: EvalFunction = {
+    name: 'make_api_request Tool Evaluation',
+    description: 'Evaluates the usage of the make_api_request tool for listing items in the Square catalog',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please use the make_api_request tool with service set to 'catalog' and method set to 'list' to retrieve all catalog items.");
+        return JSON.parse(result);
+    }
+};
+
+const get_type_infoEval: EvalFunction = {
+    name: "get_type_info Tool Evaluation",
+    description: "Evaluates the get_type_info tool functionality by retrieving type information for a Square API method",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please retrieve the type info for the 'catalog' service with the 'list' method using the get_type_info tool.");
+        return JSON.parse(result);
+    }
+};
+
+const get_service_infoEvalFunction: EvalFunction = {
+    name: "get_service_info Tool Evaluation",
+    description: "Evaluates the functionality of get_service_info tool",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Could you provide information about the 'catalog' Square API service?");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [make_api_requestEval, get_type_infoEval, get_service_infoEvalFunction]
+};
+  
+export default config;
+  
+export const evals = [make_api_requestEval, get_type_infoEval, get_service_infoEvalFunction];

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "open": "^10.1.0",
     "yaml": "^2.7.0",
     "yargs": "^17.7.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "mcp-evals": "^1.0.18"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 